### PR TITLE
useResource?

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -4,6 +4,22 @@ import { getValue } from '@glimmer/tracking/primitives/cache';
 export { modifier, Modifier } from './-private/modifiers';
 export { Resource } from './-private/resources';
 
+function normalizeArgs(args) {
+  if (Array.isArray(args)) {
+    return { positional: args };
+  }
+
+  if ('positional' in args || 'named' in args) {
+    return args;
+  }
+
+  if (typeof args === 'object') {
+    return { named: args }
+  }
+
+  return args;
+}
+
 export function use(prototype, key, desc) {
   let resources = new WeakMap();
   let { initializer } = desc;
@@ -13,17 +29,15 @@ export function use(prototype, key, desc) {
       let resource = resources.get(this);
 
       if (!resource) {
-        let { definition, args } = initializer.call(this);
+        let { definition, thunk } = initializer.call(this);
 
         resource = invokeHelper(this, definition, () => {
-          let reified = args();
-
-          if (Array.isArray(reified)) {
-            return { positional: reified };
-          }
+          let args = thunk();
+          let reified = normalizeArgs(args);
 
           return reified;
         });
+
         resources.set(this, resource);
       }
 

--- a/tests/integration/use-test.js
+++ b/tests/integration/use-test.js
@@ -6,15 +6,15 @@ import { use, Resource } from 'ember-could-get-used-to-this';
 module('@use', () => {
   test('it works', async function (assert) {
     class TestResource extends Resource {
-      @tracked firstArg;
+      constructor() {
+        super(...arguments);
 
-      setup() {
         this.firstArg = this.args.positional[0];
       }
     }
 
     class MyClass {
-      @use test = new TestResource(() => ['hello'])
+      @use test = TestResource.from(() => ['hello'])
     }
 
     let instance = new MyClass();
@@ -24,9 +24,9 @@ module('@use', () => {
 
   test('resources update if args update', async function (assert) {
     class TestResource extends Resource {
-      @tracked firstArg;
+      constructor() {
+        super(...arguments)
 
-      setup() {
         this.firstArg = this.args.positional[0];
       }
     }
@@ -34,7 +34,7 @@ module('@use', () => {
     class MyClass {
       @tracked text = 'hello'
 
-      @use test = new TestResource(() => [this.text])
+      @use test = TestResource.from(() => [this.text])
     }
 
     let instance = new MyClass();

--- a/tests/integration/use-test.js
+++ b/tests/integration/use-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { tracked } from 'tracked-built-ins';
 
-import { use, Resource } from 'ember-could-get-used-to-this';
+import { use, Resource, useResource } from 'ember-could-get-used-to-this';
 
 module('@use', () => {
   test('it works', async function (assert) {
@@ -14,7 +14,7 @@ module('@use', () => {
     }
 
     class MyClass {
-      @use test = TestResource.from(() => ['hello'])
+      @use test = TestResource.from(() => ['hello']);
     }
 
     let instance = new MyClass();
@@ -25,16 +25,16 @@ module('@use', () => {
   test('resources update if args update', async function (assert) {
     class TestResource extends Resource {
       constructor() {
-        super(...arguments)
+        super(...arguments);
 
         this.firstArg = this.args.positional[0];
       }
     }
 
     class MyClass {
-      @tracked text = 'hello'
+      @tracked text = 'hello';
 
-      @use test = TestResource.from(() => [this.text])
+      @use test = TestResource.from(() => [this.text]);
     }
 
     let instance = new MyClass();
@@ -44,5 +44,51 @@ module('@use', () => {
     instance.text = 'world';
 
     assert.equal(instance.test.firstArg, 'world');
+  });
+});
+
+module('useResource', () => {
+  test('it works', async function (assert) {
+    class TestResource extends Resource {
+      constructor() {
+        super(...arguments);
+
+        this.firstArg = this.args.positional[0];
+      }
+    }
+
+    class MyClass {
+      test = useResource(this, TestResource, () => ['hello']);
+    }
+
+    let instance = new MyClass();
+
+    assert.equal(instance.test.firstArg, 'hello');
+  });
+
+  test('example library api', async function (assert) {
+    class FakeResource extends Resource {
+      constructor() {
+        super(...arguments);
+
+        this.firstArg = this.args.positional[0];
+      }
+    }
+
+    const useFake = (ctx, thunk) => useResource(ctx, FakeResource, () => [thunk()]);
+
+    class MyClass {
+      @tracked there = 'hello';
+
+      test = useFake(this, () => this.there);
+    }
+
+    let instance = new MyClass();
+
+    assert.equal(instance.test.firstArg, 'hello');
+
+    instance.there = 'there';
+
+    assert.equal(instance.test.firstArg, 'there');
   });
 });


### PR DESCRIPTION
Kinda based off: @josemarluedke's https://gist.github.com/josemarluedke/5472064a2e1e2b2ab01c53d6da22ccb8

was trying to figure out how to reduce function calls, or the need for a Proxy.
The issue with assigning directly to a property _without_ a decorator is that you can't define a getter on that property, so when the property is accessed, the `useResource` function is not re-ran, which it is required to do -- it's identical to the `@use` decorator, except that it's not a decorator -- which means it has additional limitations. The biggest drawback is that useResource can _only_ return a single value and is not reactive
